### PR TITLE
Scan Single Interface

### DIFF
--- a/v2-src/data_upload.py
+++ b/v2-src/data_upload.py
@@ -177,7 +177,7 @@ class DataUploader(object):
                 'outbound_byte_count': flow_stats['outbound_byte_count'],
                 'syn_originator': flow_stats['syn_originator']
             }
-        
+       
         return (window_duration, {
             'dns_dict': jsonify_dict(dns_dict),
             'flow_dict': jsonify_dict(flow_dict),

--- a/v2-src/packet_capture.py
+++ b/v2-src/packet_capture.py
@@ -33,7 +33,6 @@ class PacketCapture(object):
     def _capture_packets(self):
 
         while self._is_active():
-
             if not self._host_state.is_inspecting():
                 time.sleep(2)
                 continue

--- a/v2-src/start_inspector.py
+++ b/v2-src/start_inspector.py
@@ -5,9 +5,11 @@ import utils
 import signal
 import webserver
 import time
+import scapy.all as sc
+
 
 def main():
-
+    sc.load_layer("http")
     # The whole process should be run as root.
     if os.getuid() != 0:
         sys.stderr.write('Please run as root.\n')


### PR DESCRIPTION
Instead of scanning hosts on all active interfaces, scan only interface for default specified in scapy.conf.

- Removes dependency on scapy_http, package is deprecated and absorbed by mainline scapy (scapy.layers.http)
- Adds dependency on netifaces which reads netmask from local interface rather than relying on scapy routes