### PR TITLE
open db in WAL so flows stop dropping under load (#300)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ user-data*
 3rd-party-software
 *.zip
 *.db
+*.db-wal
+*.db-shm
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/go/internal/store/store.go
+++ b/go/internal/store/store.go
@@ -56,14 +56,7 @@ type Store struct {
 }
 
 func Open(path string) (*Store, error) {
-	// Pragmas go in the DSN so the modernc driver applies them to every pooled
-	// connection (not just the first). WAL gives concurrent readers + one writer,
-	// so the lock-free web reader queries (TrafficSeries, BytesSince,
-	// InspectedCount) stop colliding with the capture writer and dropping flow
-	// rows under load. busy_timeout makes any residual contention wait rather than
-	// fail with SQLITE_BUSY; synchronous=NORMAL is the recommended pairing with WAL.
-	// Writer/writer contention is already handled in Go by the 1-slot semaphore
-	// below, so busy_timeout only ever absorbs reader/writer contention.
+	// WAL + busy_timeout via DSN (every pooled conn) so dashboard reads stop colliding with the capture writer and dropping flows.
 	dsn := path + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)"
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {

--- a/go/internal/store/store.go
+++ b/go/internal/store/store.go
@@ -56,7 +56,16 @@ type Store struct {
 }
 
 func Open(path string) (*Store, error) {
-	db, err := sql.Open("sqlite", path)
+	// Pragmas go in the DSN so the modernc driver applies them to every pooled
+	// connection (not just the first). WAL gives concurrent readers + one writer,
+	// so the lock-free web reader queries (TrafficSeries, BytesSince,
+	// InspectedCount) stop colliding with the capture writer and dropping flow
+	// rows under load. busy_timeout makes any residual contention wait rather than
+	// fail with SQLITE_BUSY; synchronous=NORMAL is the recommended pairing with WAL.
+	// Writer/writer contention is already handled in Go by the 1-slot semaphore
+	// below, so busy_timeout only ever absorbs reader/writer contention.
+	dsn := path + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)&_pragma=synchronous(NORMAL)"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +75,7 @@ func Open(path string) (*Store, error) {
 	return &Store{db: db, mu: make(chan struct{}, 1)}, nil
 }
 
-func (s *Store) DB() *sql.DB { return s.db }
+func (s *Store) DB() *sql.DB  { return s.db }
 func (s *Store) Close() error { return s.db.Close() }
 
 func (s *Store) lock()   { s.mu <- struct{}{} }


### PR DESCRIPTION
fixes #300.

under heavy traffic (a phone speed test) the live charts undercounted badly -- the db opened in rollback-journal mode with no busy timeout, so the lock-free web reader queries (TrafficSeries, BytesSince, InspectedCount) collided with the capture writer, got SQLITE_BUSY, and dropped flow rows.

sets journal_mode=WAL, busy_timeout=5000, synchronous=NORMAL via dsn pragmas so every pooled connection picks them up. WAL gives concurrent readers + one writer, so the dashboard reads stop blocking the writer.

per danny's note on the issue: writer/writer is still serialized by the existing 1-slot semaphore, and shutdown drains writers before close, so busy_timeout only ever absorbs reader/writer contention -- not write contention.

tested:
- store unit suite passes
- contention repro (writer + 8 concurrent dashboard readers): rollback mode dropped 99.8% of flows, WAL dropped 0
- live run: WAL confirmed on the running db, 365 concurrent /api/state reads during capture with 0 failures, a 17.5 MB single-second burst landed intact