### PR TITLE
fix packet drops at high capture rates (#312)

### DIFF
--- a/go/cmd/genpcap/main.go
+++ b/go/cmd/genpcap/main.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"crypto/tls"
+	"flag"
 	"log"
 	"net"
 	"os"
@@ -39,10 +40,11 @@ var (
 )
 
 func main() {
-	out := "testdata/mitm-sample.pcap"
-	if len(os.Args) > 1 {
-		out = os.Args[1]
-	}
+	out := flag.String("out", "testdata/mitm-sample.pcap", "output pcap path")
+	flood := flag.Int("n", 0, "append N forwarded data frames on one flow (load test for issue #312; 0 = just the sample)")
+	size := flag.Int("size", 1448, "payload bytes per flood data frame (≈ full-MTU TCP segment)")
+	flag.Parse()
+
 	if err := os.MkdirAll("testdata", 0o755); err != nil {
 		log.Fatal(err)
 	}
@@ -60,7 +62,7 @@ func main() {
 		tcpFrame(hostMAC, gwMAC, deviceIP, remoteIP, hello),
 	}
 
-	f, err := os.Create(out)
+	f, err := os.Create(*out)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -80,7 +82,23 @@ func main() {
 			log.Fatal(err)
 		}
 	}
-	log.Printf("wrote %s (%d packets)", out, len(frames))
+
+	// Flood: N forwarded data frames on the same 5-tuple, mimicking one
+	// download stream. Each hits processFlow → UpsertFlow (the speed-test hot
+	// path), so replaying this measures the processor ceiling for issue #312.
+	payload := gopacket.Payload(make([]byte, *size))
+	for i := 0; i < *flood; i++ {
+		data := floodFrame(uint32(i+1), payload)
+		ci := gopacket.CaptureInfo{
+			Timestamp:     time.Unix(1700001000, int64(i)),
+			CaptureLength: len(data),
+			Length:        len(data),
+		}
+		if err := w.WritePacket(ci, data); err != nil {
+			log.Fatal(err)
+		}
+	}
+	log.Printf("wrote %s (%d packets)", *out, len(frames)+*flood)
 }
 
 // clientHello returns the raw bytes of a real TLS ClientHello with the given SNI,
@@ -181,4 +199,14 @@ func tcpFrame(srcMAC, dstMAC net.HardwareAddr, srcIP, dstIP net.IP, payload []by
 	tcp := &layers.TCP{SrcPort: 51000, DstPort: 443, PSH: true, ACK: true, Seq: 1, Window: 2057}
 	_ = tcp.SetNetworkLayerForChecksum(ip)
 	return serialize(eth, ip, tcp, gopacket.Payload(payload))
+}
+
+// floodFrame is one forwarded data segment (host→gateway) on the device's flow,
+// with an advancing sequence number so it reads as a continuous stream.
+func floodFrame(seq uint32, payload gopacket.Payload) []byte {
+	eth := &layers.Ethernet{SrcMAC: hostMAC, DstMAC: gwMAC, EthernetType: layers.EthernetTypeIPv4}
+	ip := &layers.IPv4{Version: 4, IHL: 5, TTL: 64, Protocol: layers.IPProtocolTCP, SrcIP: deviceIP, DstIP: remoteIP}
+	tcp := &layers.TCP{SrcPort: 51000, DstPort: 443, PSH: true, ACK: true, Seq: seq, Window: 2057}
+	_ = tcp.SetNetworkLayerForChecksum(ip)
+	return serialize(eth, ip, tcp, payload)
 }

--- a/go/cmd/inspector/main.go
+++ b/go/cmd/inspector/main.go
@@ -48,7 +48,7 @@ func main() {
 	hostMAC := flag.String("host-mac", "", "replay: MAC of the inspector/MITM host (the side traffic is relayed through)")
 	hostIP := flag.String("host-ip", "", "replay: IP of the inspector host")
 	gatewayIP := flag.String("gateway-ip", "", "replay: gateway IP (used to tag the gateway device)")
-	inspect := flag.String("inspect", "", "live: MAC(s) to inspect (spoof+capture), comma-separated, or 'all'")
+	inspect := flag.String("inspect", "", "live: MAC(s) or IP(s) to inspect (spoof+capture), comma-separated, or 'all'")
 	serve := flag.String("serve", "", "serve the live web dashboard at this address (e.g. :8080)")
 	browse := flag.Bool("browse", false, "view an existing -db in the dashboard without capturing (no root)")
 	record := flag.String("record", "", "live: write every captured packet to this .pcap file (full-fidelity research artifact)")
@@ -240,10 +240,24 @@ func applyInspect(s *state.State, spec string) {
 			log.Printf("[inspect] now inspecting %d newly discovered device(s)", n)
 		}
 	} else {
-		for _, mac := range strings.Split(spec, ",") {
-			if mac = strings.TrimSpace(strings.ToLower(mac)); mac != "" {
-				_ = s.Store.SetInspected(mac)
+		for _, tok := range strings.Split(spec, ",") {
+			tok = strings.TrimSpace(strings.ToLower(tok))
+			if tok == "" {
+				continue
 			}
+			// Accept an IP too: resolve it to a MAC via the ARP cache. iOS hands
+			// you the IP in Settings but randomizes the MAC, so IP is the handle
+			// you usually have. The device must have been seen on the wire first;
+			// if not, skip and let the next loop iteration pick it up.
+			if ip := net.ParseIP(tok); ip != nil {
+				mac, ok := s.LookupMAC(ip)
+				if !ok {
+					log.Printf("[inspect] %s not in ARP cache yet; retrying", tok)
+					continue
+				}
+				tok = mac.String()
+			}
+			_ = s.Store.SetInspected(tok)
 		}
 	}
 	// keep the in-memory set (used to scope pcap recording) in sync with the DB

--- a/go/cmd/inspector/main.go
+++ b/go/cmd/inspector/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nyu-mlab/inspector-go/internal/arpspoof"
 	"github.com/nyu-mlab/inspector-go/internal/capture"
 	"github.com/nyu-mlab/inspector-go/internal/discovery"
+	"github.com/nyu-mlab/inspector-go/internal/metrics"
 	"github.com/nyu-mlab/inspector-go/internal/netinfo"
 	"github.com/nyu-mlab/inspector-go/internal/processor"
 	"github.com/nyu-mlab/inspector-go/internal/record"
@@ -52,6 +53,7 @@ func main() {
 	browse := flag.Bool("browse", false, "view an existing -db in the dashboard without capturing (no root)")
 	record := flag.String("record", "", "live: write every captured packet to this .pcap file (full-fidelity research artifact)")
 	openReport := flag.Bool("open", true, "open the HTML report in a browser when it's written")
+	metricsOn := flag.Bool("metrics", false, "live: log capture-pipeline profiling stats every second (find whether parsing, SQLite, or the buffer is the bottleneck)")
 	flag.Parse()
 
 	st, err := store.Open(*dbPath)
@@ -61,6 +63,9 @@ func main() {
 	defer st.Close()
 
 	s := state.New(st)
+	if *metricsOn {
+		s.Metrics = metrics.New()
+	}
 
 	switch {
 	case *browse:
@@ -179,6 +184,10 @@ func runLive(s *state.State, inspect, serveAddr, recordPath string) error {
 	go func() { defer wg.Done(); capture.Run(s, packets, rec) }() // closes `packets` when handle closes
 	go func() { defer wg.Done(); proc.Run(packets) }()
 
+	if s.Metrics != nil {
+		go runMetrics(ctx, s, packets)
+	}
+
 	// Periodic background loops (core.py's SafeLoopThreads).
 	go loop(ctx, 10*time.Second, func() { arpspoof.Scan(s) })
 	go loop(ctx, 10*time.Second, func() { arpspoof.Spoof(s) })
@@ -296,6 +305,46 @@ func loop(ctx context.Context, interval time.Duration, fn func()) {
 			return
 		case <-t.C:
 			fn()
+		}
+	}
+}
+
+// runMetrics logs the capture-pipeline profile every second so we can tell where
+// packets are lost: a full channel + high db= means SQLite is the bottleneck, a
+// full channel + high parse= means the parser is, and bpf drop climbing while the
+// channel stays empty means the kernel buffer is overflowing before userland.
+func runMetrics(ctx context.Context, s *state.State, packets chan gopacket.Packet) {
+	go func() { // sample channel occupancy faster than we report, for a real average/max
+		t := time.NewTicker(5 * time.Millisecond)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				s.Metrics.SampleChan(len(packets))
+			}
+		}
+	}()
+
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+	var prevRecv, prevDrop, prevIf int64
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			snap := s.Metrics.SnapshotAndReset()
+			var recv, drop, ifd int64
+			if st, err := s.Handle.Stats(); err == nil {
+				recv, drop, ifd = int64(st.PacketsReceived), int64(st.PacketsDropped), int64(st.PacketsIfDropped)
+			}
+			log.Printf("[metrics] cap=%d/s proc=%d/s | chan avg=%.0f max=%.0f/%d | parse=%v db=%v (flows=%d) | bpf recv=%d drop=%d ifdrop=%d",
+				snap.Captured, snap.Processed, snap.ChanAvg, snap.ChanMax, cap(packets),
+				snap.ParsePerPacket().Round(time.Microsecond), snap.DBPerCall().Round(time.Microsecond), snap.DBCalls,
+				recv-prevRecv, drop-prevDrop, ifd-prevIf)
+			prevRecv, prevDrop, prevIf = recv, drop, ifd
 		}
 	}
 }

--- a/go/internal/capture/capture.go
+++ b/go/internal/capture/capture.go
@@ -73,6 +73,7 @@ func Run(s *state.State, out chan<- gopacket.Packet, rec *record.Recorder) {
 	handle := s.Handle
 	src := gopacket.NewPacketSource(handle, handle.LinkType())
 	for pkt := range src.Packets() {
+		s.Metrics.Captured()
 		if rec != nil {
 			recordIfInspected(s, rec, pkt)
 		}

--- a/go/internal/capture/capture.go
+++ b/go/internal/capture/capture.go
@@ -17,15 +17,32 @@ import (
 const (
 	snapLen     = 65536
 	promiscuous = true
+	bufferSize  = 32 << 20 // big kernel buffer so high-rate bursts don't overflow before userland drains
 )
 
 // Open creates the live capture handle on the active interface and stores it on
 // s. The BPF filter keeps ARP (no IP layer) plus all IPv4 traffic that does not
 // involve this host — so we never capture our own forwarded copies.
 func Open(s *state.State) (*pcap.Handle, error) {
-	handle, err := pcap.OpenLive(s.Iface, snapLen, promiscuous, pcap.BlockForever)
+	inactive, err := pcap.NewInactiveHandle(s.Iface)
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", s.Iface, err)
+	}
+	defer inactive.CleanUp()
+	for _, set := range []func() error{
+		func() error { return inactive.SetSnapLen(snapLen) },
+		func() error { return inactive.SetPromisc(promiscuous) },
+		func() error { return inactive.SetTimeout(pcap.BlockForever) },
+		func() error { return inactive.SetBufferSize(bufferSize) },
+		func() error { return inactive.SetImmediateMode(true) }, // deliver as packets arrive, don't batch
+	} {
+		if err := set(); err != nil {
+			return nil, fmt.Errorf("configure %s: %w", s.Iface, err)
+		}
+	}
+	handle, err := inactive.Activate()
+	if err != nil {
+		return nil, fmt.Errorf("activate %s: %w", s.Iface, err)
 	}
 	filter := fmt.Sprintf("arp or (ip and not host %s)", s.HostIP)
 	if err := handle.SetBPFFilter(filter); err != nil {

--- a/go/internal/metrics/metrics.go
+++ b/go/internal/metrics/metrics.go
@@ -1,0 +1,108 @@
+// Package metrics is an optional capture-pipeline profiler (-metrics). It answers
+// one question: when packets get dropped under load, is the parser slow, is
+// SQLite slow, or is the kernel buffer overflowing? All counters are atomic and
+// nil-safe, so the hot path pays nothing when metrics are off (m == nil).
+package metrics
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type Metrics struct {
+	captured  atomic.Int64 // packets read off the wire
+	processed atomic.Int64 // packets run through the processor
+	processNS atomic.Int64 // cumulative time in handle()
+	dbNS      atomic.Int64 // cumulative time in the per-packet flow upsert
+	dbCalls   atomic.Int64
+	chanSum   atomic.Int64 // channel-occupancy samples, for the average
+	chanCnt   atomic.Int64
+	chanMax   atomic.Int64
+}
+
+func New() *Metrics { return &Metrics{} }
+
+func (m *Metrics) Captured() {
+	if m != nil {
+		m.captured.Add(1)
+	}
+}
+
+// Processed records one packet through handle() and how long it took (parse +
+// dispatch, including any DB time, which DB() tracks separately).
+func (m *Metrics) Processed(d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.processed.Add(1)
+	m.processNS.Add(int64(d))
+}
+
+// DB records one flow upsert and its duration.
+func (m *Metrics) DB(d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.dbCalls.Add(1)
+	m.dbNS.Add(int64(d))
+}
+
+// SampleChan records the current capture->processor channel occupancy.
+func (m *Metrics) SampleChan(n int) {
+	if m == nil {
+		return
+	}
+	m.chanSum.Add(int64(n))
+	m.chanCnt.Add(1)
+	for {
+		cur := m.chanMax.Load()
+		if int64(n) <= cur || m.chanMax.CompareAndSwap(cur, int64(n)) {
+			break
+		}
+	}
+}
+
+// Snapshot is one interval's totals. Rates are per the interval the reporter uses.
+type Snapshot struct {
+	Captured, Processed, DBCalls int64
+	ProcessNS, DBNS              int64
+	ChanAvg, ChanMax             float64
+}
+
+// ParsePerPacket is handle() time minus DB time, averaged per processed packet.
+func (s Snapshot) ParsePerPacket() time.Duration {
+	if s.Processed == 0 {
+		return 0
+	}
+	return time.Duration((s.ProcessNS - s.DBNS) / s.Processed)
+}
+
+// DBPerCall is the average flow-upsert duration.
+func (s Snapshot) DBPerCall() time.Duration {
+	if s.DBCalls == 0 {
+		return 0
+	}
+	return time.Duration(s.DBNS / s.DBCalls)
+}
+
+// SnapshotAndReset reads and zeroes every counter atomically-enough for a gauge.
+func (m *Metrics) SnapshotAndReset() Snapshot {
+	if m == nil {
+		return Snapshot{}
+	}
+	cnt := m.chanCnt.Swap(0)
+	sum := m.chanSum.Swap(0)
+	avg := 0.0
+	if cnt > 0 {
+		avg = float64(sum) / float64(cnt)
+	}
+	return Snapshot{
+		Captured:  m.captured.Swap(0),
+		Processed: m.processed.Swap(0),
+		DBCalls:   m.dbCalls.Swap(0),
+		ProcessNS: m.processNS.Swap(0),
+		DBNS:      m.dbNS.Swap(0),
+		ChanAvg:   avg,
+		ChanMax:   float64(m.chanMax.Swap(0)),
+	}
+}

--- a/go/internal/metrics/metrics_test.go
+++ b/go/internal/metrics/metrics_test.go
@@ -1,0 +1,54 @@
+package metrics
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSnapshotMath(t *testing.T) {
+	m := New()
+	for i := 0; i < 5; i++ {
+		m.Captured()
+	}
+	// two processed packets: 100µs total handle time, 60µs of it in the db.
+	m.Processed(70 * time.Microsecond)
+	m.Processed(30 * time.Microsecond)
+	m.DB(40 * time.Microsecond)
+	m.DB(20 * time.Microsecond)
+	// channel occupancy samples: avg 20, max 30.
+	m.SampleChan(10)
+	m.SampleChan(20)
+	m.SampleChan(30)
+
+	s := m.SnapshotAndReset()
+	if s.Captured != 5 || s.Processed != 2 || s.DBCalls != 2 {
+		t.Fatalf("counts: cap=%d proc=%d db=%d", s.Captured, s.Processed, s.DBCalls)
+	}
+	if s.ChanAvg != 20 || s.ChanMax != 30 {
+		t.Errorf("chan avg=%.1f max=%.1f, want 20 and 30", s.ChanAvg, s.ChanMax)
+	}
+	// parse = (100µs - 60µs) / 2 = 20µs; db = 60µs / 2 = 30µs.
+	if got := s.ParsePerPacket(); got != 20*time.Microsecond {
+		t.Errorf("parse/pkt = %v, want 20µs", got)
+	}
+	if got := s.DBPerCall(); got != 30*time.Microsecond {
+		t.Errorf("db/call = %v, want 30µs", got)
+	}
+
+	// reset is real: a fresh snapshot is empty and divides-by-zero stay 0.
+	z := m.SnapshotAndReset()
+	if z.Captured != 0 || z.ParsePerPacket() != 0 || z.DBPerCall() != 0 {
+		t.Errorf("after reset: %+v", z)
+	}
+}
+
+func TestNilIsNoOp(t *testing.T) {
+	var m *Metrics // metrics off: every call must be a safe no-op
+	m.Captured()
+	m.Processed(time.Second)
+	m.DB(time.Second)
+	m.SampleChan(99)
+	if s := m.SnapshotAndReset(); s != (Snapshot{}) {
+		t.Errorf("nil snapshot = %+v, want zero", s)
+	}
+}

--- a/go/internal/processor/processor.go
+++ b/go/internal/processor/processor.go
@@ -25,7 +25,13 @@ func New(st *state.State) *Processor { return &Processor{st: st} }
 // Run consumes packets until the channel closes.
 func (p *Processor) Run(in <-chan gopacket.Packet) {
 	for pkt := range in {
-		p.handle(pkt)
+		if m := p.st.Metrics; m != nil {
+			start := time.Now()
+			p.handle(pkt)
+			m.Processed(time.Since(start))
+		} else {
+			p.handle(pkt)
+		}
 	}
 }
 
@@ -266,9 +272,17 @@ func (p *Processor) processFlow(eth *layers.Ethernet, ip4 *layers.IPv4, pkt gopa
 		return // neither side is us; not a flow we relayed
 	}
 
-	_ = p.st.Store.UpsertFlow(time.Now().Unix(),
-		ip4.SrcIP.String(), ip4.DstIP.String(), srcMAC.String(), dstMAC.String(),
-		srcPort, dstPort, protocol, len(pkt.Data()), tcpSeq)
+	if m := p.st.Metrics; m != nil {
+		start := time.Now()
+		_ = p.st.Store.UpsertFlow(time.Now().Unix(),
+			ip4.SrcIP.String(), ip4.DstIP.String(), srcMAC.String(), dstMAC.String(),
+			srcPort, dstPort, protocol, len(pkt.Data()), tcpSeq)
+		m.DB(time.Since(start))
+	} else {
+		_ = p.st.Store.UpsertFlow(time.Now().Unix(),
+			ip4.SrcIP.String(), ip4.DstIP.String(), srcMAC.String(), dstMAC.String(),
+			srcPort, dstPort, protocol, len(pkt.Data()), tcpSeq)
+	}
 
 	// Also record the packet at full resolution (its real capture time) for the
 	// live charts, so they aren't limited to the 1-second flow buckets above.

--- a/go/internal/state/state.go
+++ b/go/internal/state/state.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/gopacket/pcap"
 
+	"github.com/nyu-mlab/inspector-go/internal/metrics"
 	"github.com/nyu-mlab/inspector-go/internal/store"
 	"github.com/nyu-mlab/inspector-go/internal/traffic"
 )
@@ -36,7 +37,8 @@ type State struct {
 
 	Handle  *pcap.Handle
 	Store   *store.Store
-	Traffic *traffic.Buffer // full-resolution rolling window for live charts (nil in browse mode)
+	Traffic *traffic.Buffer  // full-resolution rolling window for live charts (nil in browse mode)
+	Metrics *metrics.Metrics // capture-pipeline profiler (nil unless -metrics)
 
 	running atomic.Bool
 }
@@ -68,8 +70,8 @@ func (s *State) IsInspectedMAC(mac string) bool {
 	return s.inspectedMACs[strings.ToLower(mac)]
 }
 
-func (s *State) Running() bool      { return s.running.Load() }
-func (s *State) SetRunning(v bool)  { s.running.Store(v) }
+func (s *State) Running() bool     { return s.running.Load() }
+func (s *State) SetRunning(v bool) { s.running.Store(v) }
 
 // LearnARP records an IP→MAC mapping observed on the wire.
 func (s *State) LearnARP(ip net.IP, mac net.HardwareAddr) {


### PR DESCRIPTION
closes #312.

at high throughput pcap was dropping packets before userland could drain them, so flows undercounted line rate (a ~400 mbps speed test recorded only ~74 mb, peaking ~140 mbps).

this is the capture-buffer half of that problem. the db-side half (an fsync per flow write) is #311.

- capture: `NewInactiveHandle` with a 32mb buffer + immediate mode, so high-rate bursts don't overflow the default OS buffer before we read them.
- metrics: a `-metrics` flag that profiles the pipeline (captured/s, processed/s, channel occupancy, parse time, db time, bpf drops) so the bottleneck is measured, not guessed.
- genpcap: flood mode (`-n`/`-size`) to replay dense load through the processor without needing a live high-rate source.
- inspect: `-inspect` also takes an ip now, not just a mac (ios randomizes the mac but shows the ip).
