### PR TITLE
active reverse-dns so local devices get hostnames (#302)

### DIFF
--- a/go/cmd/inspector/main.go
+++ b/go/cmd/inspector/main.go
@@ -183,6 +183,8 @@ func runLive(s *state.State, inspect, serveAddr, recordPath string) error {
 	})
 	// Active SSDP discovery (mDNS is handled passively in the processor).
 	go loop(ctx, 60*time.Second, func() { discovery.SSDP(s, 10*time.Second) })
+	// Active reverse-DNS so hostnames don't depend on a passive DHCP lease firing.
+	go loop(ctx, 30*time.Second, func() { discovery.ReverseDNS(s) })
 	if inspect != "" {
 		// Make -inspect authoritative: drop any inspection left over in this DB
 		// from a previous run, so we spoof/record exactly what was asked for.

--- a/go/internal/discovery/ptr.go
+++ b/go/internal/discovery/ptr.go
@@ -1,0 +1,54 @@
+package discovery
+
+import (
+	"context"
+	"log"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nyu-mlab/inspector-go/internal/state"
+)
+
+// ReverseDNS actively resolves a PTR (reverse-DNS) record for each discovered
+// device IP that has no hostname yet, storing the result with source "ptr".
+//
+// This fills the gap left by passive DHCP (processor.processDHCP): leases renew
+// every 10-30 min but participants run the tool for ~5-10 min, so the DHCP
+// hostname often never appears. Mirrors the nmap PTR scrape in
+// routersense-raspberrypi-client/shell_command_wrapper.py, but via
+// net.LookupAddr so there's no nmap dependency.
+func ReverseDNS(s *state.State) {
+	ips, err := s.Store.DeviceIPsWithoutHostname()
+	if err != nil {
+		log.Printf("[ptr] list devices: %v", err)
+		return
+	}
+
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 8) // bound concurrent lookups
+	for _, ip := range ips {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(ip string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			names, err := net.DefaultResolver.LookupAddr(ctx, ip)
+			if err != nil || len(names) == 0 {
+				return // no PTR record, common on LANs
+			}
+			name := strings.TrimSuffix(strings.ToLower(names[0]), ".")
+			if name == "" {
+				return
+			}
+			if err := s.Store.UpsertHostname(ip, name, "ptr"); err == nil {
+				log.Printf("[ptr] %s: %s", ip, name)
+			}
+		}(ip)
+	}
+	wg.Wait()
+}

--- a/go/internal/store/store.go
+++ b/go/internal/store/store.go
@@ -219,6 +219,29 @@ func (s *Store) UpsertHostname(ip, hostname, source string) error {
 	return err
 }
 
+// DeviceIPsWithoutHostname lists discovered device IPs that have no hostname row
+// yet, so active PTR lookup only queries what's still unknown and stops once an
+// IP resolves.
+func (s *Store) DeviceIPsWithoutHostname() ([]string, error) {
+	rows, err := s.db.Query(`
+		SELECT ip_address FROM devices
+		WHERE ip_address != ''
+		  AND ip_address NOT IN (SELECT ip_address FROM hostnames)`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var ip string
+		if err := rows.Scan(&ip); err != nil {
+			return nil, err
+		}
+		out = append(out, ip)
+	}
+	return out, rows.Err()
+}
+
 // UpsertFlow increments byte/packet counts for a 5-tuple flow in the current
 // 1-second bucket, tracking min/max TCP sequence numbers in metadata (mirrors
 // process_flow, including its tcp_seq_min/max — used to estimate bytes on wire).

--- a/go/internal/store/store_test.go
+++ b/go/internal/store/store_test.go
@@ -69,3 +69,42 @@ func TestUpsertsAndReport(t *testing.T) {
 		t.Errorf("dest_hostname = %q, want example.com", destHost)
 	}
 }
+
+func TestDeviceIPsWithoutHostname(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer st.Close()
+
+	if err := st.UpsertDeviceSeen("aa:aa:aa:aa:aa:aa", "192.168.1.10", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertDeviceSeen("bb:bb:bb:bb:bb:bb", "192.168.1.11", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UpsertDeviceSeen("cc:cc:cc:cc:cc:cc", "", false); err != nil {
+		t.Fatal(err) // no IP yet -> must be excluded
+	}
+
+	// Both IP'd devices start without a hostname.
+	ips, err := st.DeviceIPsWithoutHostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(ips, ","); !strings.Contains(got, "192.168.1.10") || !strings.Contains(got, "192.168.1.11") || strings.Contains(got, ",,") || len(ips) != 2 {
+		t.Errorf("ips = %v, want exactly the two IP'd devices", ips)
+	}
+
+	// Once one resolves, it drops out.
+	if err := st.UpsertHostname("192.168.1.10", "router.lan", "ptr"); err != nil {
+		t.Fatal(err)
+	}
+	ips, err = st.DeviceIPsWithoutHostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ips) != 1 || ips[0] != "192.168.1.11" {
+		t.Errorf("ips = %v, want only 192.168.1.11", ips)
+	}
+}


### PR DESCRIPTION
closes #302.

local device hostnames came only from passive dhcp (`processor.processDHCP`), but leases renew every 10-30 min while a run lasts ~5-10 min, so the hostname often never arrives and the device stays unlabeled.

this actively resolves a PTR record for each discovered local ip that has no hostname yet (`net.LookupAddr`, no nmap dependency) and stores it via `UpsertHostname(ip, name, "ptr")`, on a 30s discovery loop. self-limiting: once an ip resolves it drops out of the work list, so it stops querying what it's already found.

remote hostnames (dns/sni) and the existing dhcp/mdns paths are untouched.
