### PR TITLE
opt-in port scan + banner grab for device id (#303)

### DIFF
--- a/go/cmd/inspector/main.go
+++ b/go/cmd/inspector/main.go
@@ -59,6 +59,7 @@ func main() {
 	share := flag.Bool("share", false, "opt in to uploading the full packet capture (.pcap) + device metadata to the research team on exit. OFF by default. see the dashboard consent notice (#306)")
 	collectEndpoint := flag.String("collect-endpoint", os.Getenv("INSPECTOR_COLLECT_ENDPOINT"), "research data collection endpoint (empty = disabled; nothing uploads without it)")
 	collectKey := flag.String("collect-key", os.Getenv("INSPECTOR_COLLECT_KEY"), "api key for the collection endpoint")
+	portScan := flag.Bool("port-scan", false, "live: actively port-scan + banner-grab inspected devices for identification (off by default)")
 	flag.Parse()
 
 	st, err := store.Open(*dbPath)
@@ -96,7 +97,7 @@ func main() {
 		if st.ShareConsent() && recordPath == "" {
 			recordPath = filepath.Join(os.TempDir(), "inspector-capture.pcap")
 		}
-		if err := runLive(s, *inspect, *serve, recordPath); err != nil {
+		if err := runLive(s, *inspect, *serve, recordPath, *portScan); err != nil {
 			log.Fatalf("%v", err)
 		}
 		livePcap = recordPath
@@ -192,7 +193,7 @@ func runReplay(s *state.State, file, hostMAC, hostIP, gatewayIP string) error {
 // runLive is the production path: discover, spoof, capture until Ctrl-C.
 // inspect selects which devices to spoof+capture: "" (none, discovery only),
 // "all", or a comma-separated MAC list.
-func runLive(s *state.State, inspect, serveAddr, recordPath string) error {
+func runLive(s *state.State, inspect, serveAddr, recordPath string, portScan bool) error {
 	if os.Geteuid() != 0 {
 		return fmt.Errorf("must run as root/admin (raw packet send + IP forwarding); use -pcap to replay a file without root")
 	}
@@ -264,6 +265,10 @@ func runLive(s *state.State, inspect, serveAddr, recordPath string) error {
 			log.Printf("warning: could not reset prior inspection state: %v", err)
 		}
 		go loop(ctx, 5*time.Second, func() { applyInspect(s, inspect) })
+		// Opt-in active port scan + banner grab of the inspected devices.
+		if portScan {
+			go loop(ctx, 120*time.Second, func() { discovery.PortScan(s) })
+		}
 	} else {
 		log.Println("discovery-only (no -inspect): devices will be listed but not spoofed")
 	}

--- a/go/internal/discovery/portscan.go
+++ b/go/internal/discovery/portscan.go
@@ -1,0 +1,150 @@
+package discovery
+
+import (
+	"errors"
+	"io"
+	"log"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nyu-mlab/inspector-go/internal/state"
+)
+
+const (
+	dialTimeout     = 1 * time.Second
+	readTimeout     = 1500 * time.Millisecond
+	probeLen        = 16 // null bytes sent when a service offers no banner
+	scanConcurrency = 12 // bound concurrent connections per device
+)
+
+// popularPorts is a small, high-signal set for device identification: remote
+// admin, web UIs, cameras, printers, IoT brokers, and streaming boxes. Kept
+// short on purpose so discovery stays fast (issue #303). Trimmed from the v1
+// tcp_scanner's ~250-port list.
+var popularPorts = []int{
+	22,   // ssh
+	23,   // telnet
+	53,   // dns
+	80,   // http
+	443,  // https
+	445,  // smb
+	554,  // rtsp (cameras)
+	631,  // ipp (printers)
+	1883, // mqtt
+	5000, // upnp / various
+	7547, // tr-069 (routers)
+	8008, // chromecast
+	8060, // roku
+	8080, // http-alt
+	8443, // https-alt
+	8883, // mqtt over tls
+	9100, // jetdirect (printers)
+}
+
+// PortScan probes the popular ports on each inspected device and records, per
+// open port, either a passive banner (the service announced itself) or how it
+// reacted to a null-byte probe (data / closed / no_response / reset). Findings
+// go to device metadata under "port_scan". Short timeouts and bounded
+// concurrency keep it fast. Scoped to inspected devices and opt-in (-port-scan),
+// since it makes active connections. Port of the v1 banner_grabber + tcp_scanner.
+func PortScan(s *state.State) {
+	devices, err := s.Store.InspectedDevices()
+	if err != nil {
+		log.Printf("[portscan] list devices: %v", err)
+		return
+	}
+	for _, d := range devices {
+		findings := map[string]any{}
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+		sem := make(chan struct{}, scanConcurrency)
+		for _, port := range popularPorts {
+			wg.Add(1)
+			sem <- struct{}{}
+			go func(port int) {
+				defer wg.Done()
+				defer func() { <-sem }()
+				if res, open := probePort(d.IP, port); open {
+					mu.Lock()
+					findings[strconv.Itoa(port)] = res
+					mu.Unlock()
+				}
+			}(port)
+		}
+		wg.Wait()
+		if len(findings) == 0 {
+			continue
+		}
+		if err := s.Store.MergeDeviceMetadataByIP(d.IP, map[string]any{"port_scan": findings}); err == nil {
+			log.Printf("[portscan] %s: %d open port(s)", d.IP, len(findings))
+		}
+	}
+}
+
+// probePort connects to ip:port and, if open, returns a finding: a passive
+// banner if the service speaks first, otherwise the reaction to a null-byte
+// probe. open is false when the port is closed, filtered, or unreachable.
+func probePort(ip string, port int) (map[string]any, bool) {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip, strconv.Itoa(port)), dialTimeout)
+	if err != nil {
+		return nil, false
+	}
+	defer conn.Close()
+	res := map[string]any{}
+	buf := make([]byte, 512)
+
+	// 1. passive banner: read without sending; some services announce themselves.
+	// Any bytes count as a banner even if the read also returned EOF (a service
+	// that speaks then immediately closes).
+	_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
+	if n, _ := conn.Read(buf); n > 0 {
+		res["banner"] = sanitize(buf[:n])
+		return res, true
+	}
+
+	// 2. active probe: send null bytes, record how the service reacts. The
+	// zero-probe behavior is itself a signal even when there's no readable banner.
+	_ = conn.SetWriteDeadline(time.Now().Add(dialTimeout))
+	if _, err := conn.Write(make([]byte, probeLen)); err != nil {
+		res["probe"] = "write_failed"
+		return res, true
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
+	n, err := conn.Read(buf)
+	switch {
+	case n > 0:
+		res["probe"] = sanitize(buf[:n])
+	case errors.Is(err, io.EOF):
+		res["probe"] = "closed"
+	case isTimeout(err):
+		res["probe"] = "no_response"
+	case err != nil && strings.Contains(strings.ToLower(err.Error()), "reset"):
+		res["probe"] = "reset"
+	default:
+		res["probe"] = "error"
+	}
+	return res, true
+}
+
+func isTimeout(err error) bool {
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
+}
+
+// sanitize keeps printable bytes only and caps length, so a hostile or binary
+// banner can't bloat or corrupt the metadata JSON.
+func sanitize(b []byte) string {
+	var sb strings.Builder
+	for _, c := range b {
+		if c == '\n' || c == '\t' || (c >= 0x20 && c < 0x7f) {
+			sb.WriteByte(c)
+		}
+		if sb.Len() >= 200 {
+			break
+		}
+	}
+	return strings.TrimSpace(sb.String())
+}

--- a/go/internal/discovery/portscan_test.go
+++ b/go/internal/discovery/portscan_test.go
@@ -1,0 +1,85 @@
+package discovery
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func listenerPort(t *testing.T, ln net.Listener) int {
+	t.Helper()
+	_, p, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, _ := strconv.Atoi(p)
+	return port
+}
+
+// A service that speaks first is captured as a passive banner.
+func TestProbePortBanner(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		_, _ = c.Write([]byte("SSH-2.0-OpenSSH_test\r\n"))
+		c.Close()
+	}()
+
+	res, open := probePort("127.0.0.1", listenerPort(t, ln))
+	if !open {
+		t.Fatal("expected open port")
+	}
+	if b, _ := res["banner"].(string); !strings.Contains(b, "SSH-2.0-OpenSSH_test") {
+		t.Errorf("banner = %v, want the SSH banner", res["banner"])
+	}
+}
+
+// A silent service that closes after the null probe reads as "closed".
+func TestProbePortActiveClose(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		_, _ = c.Read(make([]byte, probeLen)) // read the probe, send nothing
+		c.Close()
+	}()
+
+	res, open := probePort("127.0.0.1", listenerPort(t, ln))
+	if !open {
+		t.Fatal("expected open port")
+	}
+	if res["banner"] != nil {
+		t.Errorf("did not expect a banner, got %v", res["banner"])
+	}
+	if res["probe"] != "closed" {
+		t.Errorf("probe = %v, want closed", res["probe"])
+	}
+}
+
+// A port with nothing listening is reported closed.
+func TestProbePortClosed(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := listenerPort(t, ln)
+	ln.Close() // free the port so the dial is refused
+
+	if _, open := probePort("127.0.0.1", port); open {
+		t.Error("expected closed port to report not-open")
+	}
+}


### PR DESCRIPTION
closes #303.

for each inspected device it scans a small set of identifying ports (ssh, telnet, http(s), rtsp, ipp, mqtt, tr-069, chromecast, roku, smb, jetdirect) and per open port records either:

- a passive banner, if the service speaks first (e.g. ssh replies `SSH-2.0-...`), or
- how it reacts to a null-byte probe (data / closed / no_response / reset) when there's no banner.

findings go to device metadata under `port_scan`.

off by default behind `-port-scan`, and scoped to inspected devices only since it makes active connections. short timeouts (1s dial, 1.5s read), bounded to 12 concurrent connections, on a 120s loop. trimmed from the v1 banner_grabber/tcp_scanner ~250-port list to a high-signal set.
