### PR TITLE
make the html report user-friendly (#305)

### DIFF
--- a/go/cmd/inspector/main.go
+++ b/go/cmd/inspector/main.go
@@ -17,7 +17,9 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -49,6 +51,7 @@ func main() {
 	serve := flag.String("serve", "", "serve the live web dashboard at this address (e.g. :8080)")
 	browse := flag.Bool("browse", false, "view an existing -db in the dashboard without capturing (no root)")
 	record := flag.String("record", "", "live: write every captured packet to this .pcap file (full-fidelity research artifact)")
+	openReport := flag.Bool("open", true, "open the HTML report in a browser when it's written")
 	flag.Parse()
 
 	st, err := store.Open(*dbPath)
@@ -77,6 +80,9 @@ func main() {
 		log.Printf("report: %v", err)
 	} else {
 		log.Printf("wrote %s", *reportPath)
+		if *openReport {
+			openInBrowser(*reportPath)
+		}
 	}
 }
 
@@ -257,6 +263,24 @@ func startWebServer(s *state.State, addr string) {
 			log.Printf("web server: %v", err)
 		}
 	}()
+}
+
+// openInBrowser opens path with the OS default handler (issue #305). Best-effort:
+// on a headless box the opener just won't exist, which is fine.
+func openInBrowser(path string) {
+	var cmd string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+	case "windows":
+		cmd, args = "cmd", []string{"/c", "start", ""}
+	default:
+		cmd = "xdg-open"
+	}
+	if err := exec.Command(cmd, append(args, path)...).Start(); err != nil {
+		log.Printf("could not open report (%s); open %s manually", err, path)
+	}
 }
 
 // loop runs fn immediately, then every interval, until ctx is cancelled.

--- a/go/internal/report/report.go
+++ b/go/internal/report/report.go
@@ -4,92 +4,116 @@
 package report
 
 import (
+	"fmt"
 	"html/template"
 	"os"
+	"sort"
+	"strings"
 
 	"github.com/nyu-mlab/inspector-go/internal/store"
 )
 
+// deviceRow is one line in the report: who the device is, who it talked to most,
+// and how much data it sent vs received. No raw "flow" counts — end users care
+// about bytes up/down, not internal flow records (issue #305).
 type deviceRow struct {
-	MAC, IP, Vendor, Hostname string
-	FlowCount                 int
-}
-
-type topFlow struct {
-	Device, Dest string
-	Bytes        int64
+	Name, MAC, VendorType, TopDest string
+	Up, Down                       int64
 }
 
 type page struct {
 	Devices []deviceRow
-	Flows   []topFlow
 }
 
-var tmpl = template.Must(template.New("report").Parse(`<!doctype html>
+var funcs = template.FuncMap{"bytes": humanBytes}
+
+// humanBytes formats a byte count as B/KB/MB/GB/TB.
+func humanBytes(n int64) string {
+	const u = 1024
+	if n < u {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(u), 0
+	for x := n / u; x >= u; x /= u {
+		div *= u
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGT"[exp])
+}
+
+var tmpl = template.Must(template.New("report").Funcs(funcs).Parse(`<!doctype html>
 <html><head><meta charset="utf-8"><title>inspector-go report</title>
 <style>
- body{font:14px system-ui,sans-serif;margin:2rem;max-width:60rem}
+ body{font:14px system-ui,sans-serif;margin:2rem;max-width:64rem;color:#1f2430}
+ h1{font-size:1.3rem;margin:0 0 .2rem}
  table{border-collapse:collapse;width:100%;margin:1rem 0}
- th,td{border-bottom:1px solid #ddd;padding:.4rem .6rem;text-align:left}
- th{background:#f5f5f5}
+ th,td{border-bottom:1px solid #e3e8ef;padding:.5rem .6rem;text-align:left;vertical-align:top}
+ th{background:#f5f6f8;font-size:.8rem;text-transform:uppercase;letter-spacing:.03em;color:#6b7280}
+ td.num,th.num{text-align:right;font-variant-numeric:tabular-nums}
+ .mut{color:#6b7280}
+ code{background:#f0f2f5;padding:.05rem .3rem;border-radius:.3rem;font-size:.85em}
 </style></head><body>
 <h1>Network report</h1>
-<h2>Devices ({{len .Devices}})</h2>
-<table><tr><th>Device</th><th>IP</th><th>MAC</th><th>Vendor</th><th>Flows</th></tr>
-{{range .Devices}}<tr><td>{{.Hostname}}</td><td>{{.IP}}</td><td>{{.MAC}}</td><td>{{.Vendor}}</td><td>{{.FlowCount}}</td></tr>{{end}}
+<p class="mut">{{len .Devices}} device(s). Upload is data the device sent; download is data it received.</p>
+{{if .Devices}}
+<table>
+<tr><th>Device</th><th>MAC</th><th>Vendor / Type</th><th>Top destination</th><th class="num">↑ Uploaded</th><th class="num">↓ Downloaded</th></tr>
+{{range .Devices}}<tr>
+ <td>{{.Name}}</td>
+ <td><code>{{.MAC}}</code></td>
+ <td>{{if .VendorType}}{{.VendorType}}{{else}}<span class="mut">—</span>{{end}}</td>
+ <td>{{if .TopDest}}{{.TopDest}}{{else}}<span class="mut">—</span>{{end}}</td>
+ <td class="num">{{bytes .Up}}</td>
+ <td class="num">{{bytes .Down}}</td>
+</tr>{{end}}
 </table>
-<h2>Top destinations by bytes</h2>
-<table><tr><th>Device</th><th>Destination</th><th>Bytes</th></tr>
-{{range .Flows}}<tr><td>{{.Device}}</td><td>{{.Dest}}</td><td>{{.Bytes}}</td></tr>{{end}}
-</table>
+{{else}}<p class="mut">No devices captured.</p>{{end}}
 </body></html>`))
 
-// Generate writes an HTML report to path, summarizing the captured data.
+// Generate writes a single-table HTML report to path.
 func Generate(st *store.Store, path string) error {
 	db := st.DB()
-
 	var p page
 
-	devRows, err := db.Query(`
-		SELECT d.mac_address, d.ip_address,
-		       COALESCE(json_extract(d.metadata_json,'$.oui_vendor'),''),
-		       COALESCE((SELECT hostname FROM hostnames WHERE ip_address = d.ip_address),''),
-		       (SELECT COUNT(*) FROM network_flows f
-		         WHERE f.src_mac_address = d.mac_address OR f.dest_mac_address = d.mac_address)
-		FROM devices d WHERE d.is_gateway = 0
-		ORDER BY d.ip_address`)
+	rows, err := db.Query(`
+		SELECT d.mac_address,
+		  COALESCE(json_extract(d.metadata_json,'$.name'),''),
+		  COALESCE(json_extract(d.metadata_json,'$.dhcp_hostname'),''),
+		  COALESCE((SELECT hostname FROM hostnames WHERE ip_address = d.ip_address),''),
+		  COALESCE(json_extract(d.metadata_json,'$.vendor_confirmed'), json_extract(d.metadata_json,'$.oui_vendor'),''),
+		  COALESCE(json_extract(d.metadata_json,'$.type_confirmed'),''),
+		  COALESCE((SELECT SUM(byte_count) FROM network_flows WHERE src_mac_address = d.mac_address),0),
+		  COALESCE((SELECT SUM(byte_count) FROM network_flows WHERE dest_mac_address = d.mac_address),0),
+		  COALESCE((SELECT COALESCE(NULLIF(dest_hostname,''),dest_ip_address) AS h
+		            FROM network_flows WHERE src_mac_address = d.mac_address
+		            GROUP BY h ORDER BY SUM(byte_count) DESC LIMIT 1),'')
+		FROM devices d WHERE d.is_gateway = 0`)
 	if err != nil {
 		return err
 	}
-	for devRows.Next() {
-		var r deviceRow
-		if err := devRows.Scan(&r.MAC, &r.IP, &r.Vendor, &r.Hostname, &r.FlowCount); err != nil {
-			devRows.Close()
+	defer rows.Close()
+	for rows.Next() {
+		var mac, name, dhcp, hostname, vendor, typ, topDest string
+		var up, down int64
+		if err := rows.Scan(&mac, &name, &dhcp, &hostname, &vendor, &typ, &up, &down, &topDest); err != nil {
 			return err
 		}
-		p.Devices = append(p.Devices, r)
+		p.Devices = append(p.Devices, deviceRow{
+			Name:       displayName(name, dhcp, hostname, vendor, mac),
+			MAC:        mac,
+			VendorType: vendorType(vendor, typ),
+			TopDest:    topDest,
+			Up:         up,
+			Down:       down,
+		})
 	}
-	devRows.Close()
-
-	flowRows, err := db.Query(`
-		SELECT src_mac_address,
-		       COALESCE(NULLIF(dest_hostname,''), dest_ip_address),
-		       SUM(byte_count) AS bytes
-		FROM network_flows
-		GROUP BY src_mac_address, dest_ip_address
-		ORDER BY bytes DESC LIMIT 50`)
-	if err != nil {
+	if err := rows.Err(); err != nil {
 		return err
 	}
-	for flowRows.Next() {
-		var f topFlow
-		if err := flowRows.Scan(&f.Device, &f.Dest, &f.Bytes); err != nil {
-			flowRows.Close()
-			return err
-		}
-		p.Flows = append(p.Flows, f)
-	}
-	flowRows.Close()
+	// Most active device first, by total bytes moved.
+	sort.SliceStable(p.Devices, func(i, j int) bool {
+		return p.Devices[i].Up+p.Devices[i].Down > p.Devices[j].Up+p.Devices[j].Down
+	})
 
 	out, err := os.Create(path)
 	if err != nil {
@@ -97,4 +121,30 @@ func Generate(st *store.Store, path string) error {
 	}
 	defer out.Close()
 	return tmpl.Execute(out, p)
+}
+
+// displayName picks the friendliest label available, falling back to a stable
+// "Unnamed Device XX" from the last MAC octet.
+func displayName(name, dhcp, hostname, vendor, mac string) string {
+	for _, c := range []string{name, dhcp, hostname, vendor} {
+		if c != "" {
+			return c
+		}
+	}
+	h := strings.ReplaceAll(mac, ":", "")
+	if len(h) >= 2 {
+		return "Unnamed Device " + strings.ToUpper(h[len(h)-2:])
+	}
+	return "Unknown"
+}
+
+func vendorType(vendor, typ string) string {
+	switch {
+	case vendor != "" && typ != "":
+		return vendor + " · " + typ
+	case vendor != "":
+		return vendor
+	default:
+		return typ
+	}
 }

--- a/go/internal/report/report_test.go
+++ b/go/internal/report/report_test.go
@@ -1,0 +1,69 @@
+package report
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nyu-mlab/inspector-go/internal/store"
+)
+
+func TestGenerate(t *testing.T) {
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	const camMAC, rokuMAC, gwMAC = "aa:aa:aa:00:00:01", "bb:bb:bb:00:00:01", "cc:cc:cc:00:00:fe"
+	_ = st.UpsertDeviceSeen(camMAC, "192.168.1.10", false)
+	_ = st.UpsertDeviceSeen(rokuMAC, "192.168.1.11", false)
+	_ = st.UpsertDeviceSeen(gwMAC, "192.168.1.1", true) // gateway -> excluded
+	_ = st.MergeDeviceMetadata(camMAC, "", map[string]any{"oui_vendor": "Acme", "dhcp_hostname": "front-cam"})
+	_ = st.MergeDeviceMetadata(rokuMAC, "", map[string]any{"oui_vendor": "Roku"})
+
+	// cam: 5 KB up to a known host, 20 KB down. roku: a little up.
+	_ = st.UpsertHostname("93.184.216.34", "example.com", "dns")
+	_ = st.UpsertFlow(1000, "192.168.1.10", "93.184.216.34", camMAC, gwMAC, 50000, 443, "tcp", 5000, 1)
+	_ = st.UpsertFlow(1000, "93.184.216.34", "192.168.1.10", gwMAC, camMAC, 443, 50000, "tcp", 20000, 1)
+	_ = st.UpsertFlow(1000, "192.168.1.11", "8.8.8.8", rokuMAC, gwMAC, 51000, 53, "udp", 200, 0)
+	if _, err := st.BackfillFlowHostnames(); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, "report.html")
+	if err := Generate(st, path); err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	html := string(b)
+
+	for _, want := range []string{
+		"front-cam",   // friendly name from dhcp hostname
+		"example.com", // top destination (hostname, not raw ip)
+		"KB",          // human-readable bytes
+		"Uploaded",    // up/down columns
+		"Downloaded",
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("report missing %q", want)
+		}
+	}
+	// The raw "Flows" column must be gone.
+	if strings.Contains(html, ">Flows<") {
+		t.Error("report still shows the raw Flows column")
+	}
+	// Gateway excluded.
+	if strings.Contains(html, gwMAC) {
+		t.Error("gateway should not appear in the report")
+	}
+	// cam (25 KB) should sort above roku (200 B).
+	if strings.Index(html, "front-cam") > strings.Index(html, "Roku") {
+		t.Error("devices not ordered by total bytes (cam should precede roku)")
+	}
+}


### PR DESCRIPTION
closes #305.

the report showed a raw 'flows' count and two tables of plain byte numbers, none of it meaningful to end users. it's now a single table:

device · mac · vendor / type · top destination · ↑ uploaded · ↓ downloaded

- dropped 'flows'; per device it shows total data sent (upload) and received (download), which is the privacy-relevant number.
- bytes are human-readable (KB/MB/GB).
- one consolidated table, sorted by total bytes, gateway excluded, friendly names with an "Unnamed Device XX" fallback.
- the report opens automatically when written (`-open`, on by default).

verified via live run(s): a seeded capture renders the table with hostnames, human-readable totals, and no raw flow counts.

the mislabeled-device case (the Fire TV) is its own tracked work in #232, not touched here.
