### PR TITLE
opt-in research data collection (#306)

### DIFF
--- a/go/cmd/inspector/main.go
+++ b/go/cmd/inspector/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/nyu-mlab/inspector-go/internal/arpspoof"
 	"github.com/nyu-mlab/inspector-go/internal/capture"
+	"github.com/nyu-mlab/inspector-go/internal/collect"
 	"github.com/nyu-mlab/inspector-go/internal/discovery"
 	"github.com/nyu-mlab/inspector-go/internal/metrics"
 	"github.com/nyu-mlab/inspector-go/internal/netinfo"
@@ -54,6 +56,9 @@ func main() {
 	record := flag.String("record", "", "live: write every captured packet to this .pcap file (full-fidelity research artifact)")
 	openReport := flag.Bool("open", true, "open the HTML report in a browser when it's written")
 	metricsOn := flag.Bool("metrics", false, "live: log capture-pipeline profiling stats every second (find whether parsing, SQLite, or the buffer is the bottleneck)")
+	share := flag.Bool("share", false, "opt in to uploading the full packet capture (.pcap) + device metadata to the research team on exit. OFF by default. see the dashboard consent notice (#306)")
+	collectEndpoint := flag.String("collect-endpoint", os.Getenv("INSPECTOR_COLLECT_ENDPOINT"), "research data collection endpoint (empty = disabled; nothing uploads without it)")
+	collectKey := flag.String("collect-key", os.Getenv("INSPECTOR_COLLECT_KEY"), "api key for the collection endpoint")
 	flag.Parse()
 
 	st, err := store.Open(*dbPath)
@@ -67,6 +72,15 @@ func main() {
 		s.Metrics = metrics.New()
 	}
 
+	// -share is an explicit CLI opt-in for headless runs (#306): persist consent
+	// before anything captures.
+	if *share {
+		if err := st.SetShareConsent(true); err != nil {
+			log.Printf("warning: could not persist share consent: %v", err)
+		}
+	}
+
+	var livePcap string // set only for a live capture, so only live runs can upload
 	switch {
 	case *browse:
 		runBrowse(s, *serve)
@@ -76,9 +90,16 @@ func main() {
 			log.Fatalf("replay: %v", err)
 		}
 	default:
-		if err := runLive(s, *inspect, *serve, *record); err != nil {
+		// When consent is on, make sure a pcap is actually captured so there's
+		// something to share (the user may not have passed -record themselves).
+		recordPath := *record
+		if st.ShareConsent() && recordPath == "" {
+			recordPath = filepath.Join(os.TempDir(), "inspector-capture.pcap")
+		}
+		if err := runLive(s, *inspect, *serve, recordPath); err != nil {
 			log.Fatalf("%v", err)
 		}
+		livePcap = recordPath
 	}
 
 	if err := report.Generate(st, *reportPath); err != nil {
@@ -89,6 +110,42 @@ func main() {
 			openInBrowser(*reportPath)
 		}
 	}
+
+	// The one place raw packets can leave the machine. Gated on consent.
+	if livePcap != "" {
+		maybeUploadCapture(st, livePcap, *collectEndpoint, *collectKey)
+	}
+}
+
+// maybeUploadCapture uploads the capture to the research endpoint ONLY when the
+// user has explicitly consented (#306) and an endpoint is configured. The
+// consent check here is the hard gate; without it nothing is sent.
+func maybeUploadCapture(st *store.Store, pcapPath, endpoint, apiKey string) {
+	if !st.ShareConsent() {
+		return // no consent -> never upload
+	}
+	if endpoint == "" {
+		log.Printf("[share] consent is on but no -collect-endpoint configured; not uploading")
+		return
+	}
+	info, err := os.Stat(pcapPath)
+	if err != nil || info.Size() == 0 {
+		log.Printf("[share] consent is on but there's no capture to upload yet")
+		return
+	}
+	meta, err := st.ExportMetadata()
+	if err != nil {
+		log.Printf("[share] could not build metadata: %v", err)
+		return
+	}
+	log.Printf("[share] consent given — uploading %s (%d bytes) + metadata to %s", pcapPath, info.Size(), endpoint)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+	if err := collect.New(endpoint, apiKey).Upload(ctx, pcapPath, meta); err != nil {
+		log.Printf("[share] upload failed: %v", err)
+		return
+	}
+	log.Printf("[share] upload complete")
 }
 
 // runReplay drives the processor over a pcap file. Because the live processor

--- a/go/cmd/inspector/main_test.go
+++ b/go/cmd/inspector/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/nyu-mlab/inspector-go/internal/store"
+)
+
+// The consent gate is the load-bearing safety control for #306: raw captures
+// must never leave the machine unless the user explicitly opted in AND an
+// endpoint is configured.
+func TestMaybeUploadGate(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	st, err := store.Open(filepath.Join(dir, "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	pcap := filepath.Join(dir, "c.pcap")
+	if err := os.WriteFile(pcap, []byte("rawpackets"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Consent OFF (the default): must NOT upload, even with an endpoint set.
+	maybeUploadCapture(st, pcap, srv.URL, "")
+	if n := atomic.LoadInt32(&hits); n != 0 {
+		t.Fatalf("uploaded without consent (hits=%d) — gate is broken", n)
+	}
+
+	// Consent ON + endpoint: uploads.
+	if err := st.SetShareConsent(true); err != nil {
+		t.Fatal(err)
+	}
+	maybeUploadCapture(st, pcap, srv.URL, "")
+	if n := atomic.LoadInt32(&hits); n != 1 {
+		t.Errorf("expected exactly one upload after consent, got %d", n)
+	}
+
+	// Consent ON but no endpoint configured: must NOT upload.
+	atomic.StoreInt32(&hits, 0)
+	maybeUploadCapture(st, pcap, "", "")
+	if n := atomic.LoadInt32(&hits); n != 0 {
+		t.Errorf("uploaded with no endpoint (hits=%d)", n)
+	}
+}

--- a/go/internal/collect/collect.go
+++ b/go/internal/collect/collect.go
@@ -1,0 +1,86 @@
+// Package collect implements the opt-in research data upload (issue #306). It
+// streams the full packet capture plus a metadata JSON to a configurable
+// endpoint as multipart/form-data.
+//
+// SAFETY: nothing here decides whether to send. The caller MUST verify explicit
+// user consent (store.ShareConsent) before calling Upload. Upload also refuses
+// to run with an empty endpoint, so a missing config can never silently send.
+package collect
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type Client struct {
+	Endpoint string
+	APIKey   string
+	http     *http.Client
+}
+
+func New(endpoint, apiKey string) *Client {
+	return &Client{
+		Endpoint: endpoint,
+		APIKey:   apiKey,
+		http:     &http.Client{Timeout: 10 * time.Minute}, // pcaps can be large
+	}
+}
+
+// Upload streams the pcap at pcapPath and the metadata JSON to the endpoint as
+// one multipart POST. It errors (without sending) if the endpoint is empty.
+func (c *Client) Upload(ctx context.Context, pcapPath string, metadata []byte) error {
+	if c.Endpoint == "" {
+		return fmt.Errorf("no collection endpoint configured")
+	}
+	f, err := os.Open(pcapPath)
+	if err != nil {
+		return fmt.Errorf("open pcap: %w", err)
+	}
+	defer f.Close()
+
+	// Stream the multipart body through a pipe so a large pcap never has to sit
+	// in memory.
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+	go func() {
+		var werr error
+		defer func() { _ = pw.CloseWithError(werr) }()
+		if werr = mw.WriteField("metadata", string(metadata)); werr != nil {
+			return
+		}
+		var fw io.Writer
+		if fw, werr = mw.CreateFormFile("pcap", filepath.Base(pcapPath)); werr != nil {
+			return
+		}
+		if _, werr = io.Copy(fw, f); werr != nil {
+			return
+		}
+		werr = mw.Close()
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.Endpoint, pr)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	if c.APIKey != "" {
+		req.Header.Set("x-api-key", c.APIKey)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("collection endpoint returned %s: %s", resp.Status, b)
+	}
+	return nil
+}

--- a/go/internal/collect/collect_test.go
+++ b/go/internal/collect/collect_test.go
@@ -1,0 +1,68 @@
+package collect
+
+import (
+	"context"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// An empty endpoint must error without sending anything.
+func TestUploadNoEndpoint(t *testing.T) {
+	if err := New("", "").Upload(context.Background(), "x.pcap", []byte("{}")); err == nil {
+		t.Fatal("expected error with empty endpoint, got nil (must never send)")
+	}
+}
+
+// With an endpoint, the pcap and metadata arrive as multipart parts, with the key.
+func TestUpload(t *testing.T) {
+	pcap := filepath.Join(t.TempDir(), "cap.pcap")
+	if err := os.WriteFile(pcap, []byte("\xd4\xc3\xb2\xa1rawpackets"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var gotPcap, gotMeta, gotKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("x-api-key")
+		_, params, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		mr := multipart.NewReader(r.Body, params["boundary"])
+		for {
+			part, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Error(err)
+				break
+			}
+			b, _ := io.ReadAll(part)
+			switch part.FormName() {
+			case "pcap":
+				gotPcap = string(b)
+			case "metadata":
+				gotMeta = string(b)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	if err := New(srv.URL, "secret").Upload(context.Background(), pcap, []byte(`{"devices":[]}`)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(gotPcap, "rawpackets") {
+		t.Errorf("server did not receive the pcap bytes, got %q", gotPcap)
+	}
+	if gotMeta != `{"devices":[]}` {
+		t.Errorf("metadata = %q, want the json blob", gotMeta)
+	}
+	if gotKey != "secret" {
+		t.Errorf("x-api-key = %q, want secret", gotKey)
+	}
+}

--- a/go/internal/store/store.go
+++ b/go/internal/store/store.go
@@ -48,6 +48,10 @@ CREATE TABLE IF NOT EXISTS network_flows (
     metadata_json    TEXT DEFAULT '{}',
     PRIMARY KEY (timestamp, src_mac_address, dest_mac_address,
                  src_ip_address, dest_ip_address, src_port, dest_port, protocol)
+);
+CREATE TABLE IF NOT EXISTS settings (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
 );`
 
 type Store struct {
@@ -70,6 +74,42 @@ func Open(path string) (*Store, error) {
 
 func (s *Store) DB() *sql.DB  { return s.db }
 func (s *Store) Close() error { return s.db.Close() }
+
+// shareConsentKey is the settings row that gates research data upload (#306).
+// Absent or anything other than "true" means no consent — uploads never happen.
+const shareConsentKey = "share_consent"
+
+// SetSetting upserts a key/value into the settings table.
+func (s *Store) SetSetting(key, value string) error {
+	s.lock()
+	defer s.unlock()
+	_, err := s.db.Exec(`
+		INSERT INTO settings (key, value) VALUES (?, ?)
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value`, key, value)
+	return err
+}
+
+// GetSetting returns the value for key, or "" if it isn't set.
+func (s *Store) GetSetting(key string) (string, error) {
+	var v string
+	err := s.db.QueryRow(`SELECT value FROM settings WHERE key = ?`, key).Scan(&v)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return v, err
+}
+
+// ShareConsent reports whether the user has explicitly consented to uploading
+// raw captures to the research team. Defaults to false (opt-in only).
+func (s *Store) ShareConsent() bool {
+	v, _ := s.GetSetting(shareConsentKey)
+	return v == "true"
+}
+
+// SetShareConsent persists the user's consent decision.
+func (s *Store) SetShareConsent(on bool) error {
+	return s.SetSetting(shareConsentKey, strconv.FormatBool(on))
+}
 
 func (s *Store) lock()   { s.mu <- struct{}{} }
 func (s *Store) unlock() { <-s.mu }

--- a/go/internal/store/store.go
+++ b/go/internal/store/store.go
@@ -111,6 +111,59 @@ func (s *Store) SetShareConsent(on bool) error {
 	return s.SetSetting(shareConsentKey, strconv.FormatBool(on))
 }
 
+// ExportMetadata returns the parsed identification data (devices and hostnames)
+// as JSON — the "metadata" half of the #306 upload payload that accompanies the
+// raw pcap.
+func (s *Store) ExportMetadata() ([]byte, error) {
+	type device struct {
+		MAC       string         `json:"mac"`
+		IP        string         `json:"ip"`
+		Gateway   bool           `json:"gateway"`
+		Inspected bool           `json:"inspected"`
+		Metadata  map[string]any `json:"metadata"`
+	}
+	out := struct {
+		Devices   []device          `json:"devices"`
+		Hostnames map[string]string `json:"hostnames"`
+	}{Hostnames: map[string]string{}}
+
+	dr, err := s.db.Query(`SELECT mac_address, ip_address, is_gateway, is_inspected, metadata_json FROM devices`)
+	if err != nil {
+		return nil, err
+	}
+	for dr.Next() {
+		var d device
+		var gw, insp int
+		var meta string
+		if err := dr.Scan(&d.MAC, &d.IP, &gw, &insp, &meta); err != nil {
+			dr.Close()
+			return nil, err
+		}
+		d.Gateway, d.Inspected = gw == 1, insp == 1
+		d.Metadata = map[string]any{}
+		_ = json.Unmarshal([]byte(meta), &d.Metadata)
+		out.Devices = append(out.Devices, d)
+	}
+	dr.Close()
+	if err := dr.Err(); err != nil {
+		return nil, err
+	}
+
+	hr, err := s.db.Query(`SELECT ip_address, hostname FROM hostnames`)
+	if err != nil {
+		return nil, err
+	}
+	defer hr.Close()
+	for hr.Next() {
+		var ip, h string
+		if err := hr.Scan(&ip, &h); err != nil {
+			return nil, err
+		}
+		out.Hostnames[ip] = h
+	}
+	return json.MarshalIndent(out, "", "  ")
+}
+
 func (s *Store) lock()   { s.mu <- struct{}{} }
 func (s *Store) unlock() { <-s.mu }
 

--- a/go/internal/store/store_test.go
+++ b/go/internal/store/store_test.go
@@ -108,3 +108,50 @@ func TestDeviceIPsWithoutHostname(t *testing.T) {
 		t.Errorf("ips = %v, want only 192.168.1.11", ips)
 	}
 }
+
+func TestShareConsent(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer st.Close()
+
+	if st.ShareConsent() {
+		t.Fatal("consent must default to false (opt-in only)")
+	}
+	if err := st.SetShareConsent(true); err != nil {
+		t.Fatal(err)
+	}
+	if !st.ShareConsent() {
+		t.Error("consent should be true after opt-in")
+	}
+	if err := st.SetShareConsent(false); err != nil {
+		t.Fatal(err)
+	}
+	if st.ShareConsent() {
+		t.Error("consent should be false after opt-out")
+	}
+}
+
+func TestExportMetadata(t *testing.T) {
+	st, err := Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer st.Close()
+
+	_ = st.UpsertDeviceSeen("aa:aa:aa:aa:aa:aa", "192.168.1.9", false)
+	_ = st.MergeDeviceMetadata("aa:aa:aa:aa:aa:aa", "", map[string]any{"oui_vendor": "Acme"})
+	_ = st.UpsertHostname("93.184.216.34", "example.com", "dns")
+
+	b, err := st.ExportMetadata()
+	if err != nil {
+		t.Fatal(err)
+	}
+	js := string(b)
+	for _, want := range []string{"aa:aa:aa:aa:aa:aa", "Acme", "example.com", "192.168.1.9"} {
+		if !strings.Contains(js, want) {
+			t.Errorf("export metadata missing %q\n%s", want, js)
+		}
+	}
+}

--- a/go/internal/web/templates.go
+++ b/go/internal/web/templates.go
@@ -75,6 +75,9 @@ const base = `
  .label-form input { flex:1; max-width:22rem; padding:.25rem .45rem; border:1px solid var(--line); border-radius:.3rem; font:inherit }
  .label-form button { padding:.25rem .8rem; border:1px solid var(--line); border-radius:.3rem; background:var(--card); color:var(--fg); cursor:pointer }
  .label-form .hint { color:var(--mut); font-size:.8rem }
+ .consent { background:#fff8e6; border:1px solid #f0d98a; border-radius:.6rem; padding:.8rem 1rem; margin:0 0 1.2rem }
+ .consent label { display:flex; align-items:center; gap:.5rem; font-weight:600; cursor:pointer }
+ .consent .disc { color:#6b7280; font-size:.82rem; margin:.45rem 0 0 }
 </style>`
 
 // chartJS holds the shared client-side drawing helpers, so the live list and the
@@ -118,6 +121,10 @@ var indexTmpl = template.Must(template.New("index").Funcs(funcs).Parse(`<!doctyp
  <div class="metric"><div class="v" id="m-insp">–</div><div class="l">inspected</div></div>
  <div class="metric"><div class="v" id="m-data">–</div><div class="l">data use · last 10s</div></div>
 </div>
+<div class="consent" id="consent">
+ <label><input type="checkbox" id="consent-box"> Share my data with the research team</label>
+ <div class="disc">We collect data to understand device behavior. Off by default. If you turn this on, when this session ends IoT Inspector uploads the full packet capture (.pcap) of the inspected devices, plus the accompanying device metadata, to the research team's collection endpoint. Only enable this if you understand and consent to sharing your network traffic for research.</div>
+</div>
 <div id="devices"></div>
 </main>
 <script>` + chartJS + `
@@ -149,8 +156,19 @@ async function tick(){
     document.getElementById('m-data').textContent = hb(d.dataUse);
     document.getElementById('devices').innerHTML = (d.list||[]).map(card).join('') || '<p class="empty">No devices yet — discovery in progress.</p>';
     document.getElementById('status').textContent = 'live · updating every 1.5s';
+    // Reflect persisted consent once, so we don't fight the user mid-toggle.
+    if(!consentInit && typeof d.consent === 'boolean'){
+      consentInit = true;
+      document.getElementById('consent-box').checked = d.consent;
+    }
   }catch(e){ document.getElementById('status').textContent = 'disconnected'; }
 }
+// Consent is a single static control outside the polled #devices region, so the
+// 1.5s redraw never clobbers it (issue #304's read-only-list lesson).
+let consentInit = false;
+document.getElementById('consent-box').addEventListener('change', async function(){
+  try{ await fetch('/consent?on=' + (this.checked ? 1 : 0)); }catch(e){}
+});
 tick(); setInterval(tick, 1500);
 </script>
 </body></html>`))

--- a/go/internal/web/templates.go
+++ b/go/internal/web/templates.go
@@ -113,8 +113,8 @@ function esc(s){return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').repl
 `
 
 var indexTmpl = template.Must(template.New("index").Funcs(funcs).Parse(`<!doctype html><html><head>
-<meta charset="utf-8"><title>inspector-go</title>` + base + `</head><body>
-<header><h1>inspector-go</h1><span class="mut" id="status">connecting…</span></header>
+<meta charset="utf-8"><title>IoT Inspector</title>` + base + `</head><body>
+<header><h1>IoT Inspector</h1><span class="mut" id="status">connecting…</span></header>
 <main>
 <div class="metrics">
  <div class="metric"><div class="v" id="m-dev">–</div><div class="l">devices seen</div></div>
@@ -174,7 +174,7 @@ tick(); setInterval(tick, 1500);
 </body></html>`))
 
 var deviceTmpl = template.Must(template.New("device").Funcs(funcs).Parse(`<!doctype html><html><head>
-<meta charset="utf-8"><title>{{if .Name}}{{.Name}}{{else}}{{.MAC}}{{end}} · inspector-go</title>` + base + `</head><body>
+<meta charset="utf-8"><title>{{if .Name}}{{.Name}}{{else}}{{.MAC}}{{end}} · IoT Inspector</title>` + base + `</head><body>
 <header><h1><a href="/">← devices</a></h1>
 <span>{{if .Name}}{{.Name}}{{else}}<span class="empty">unknown device</span>{{end}}</span>
 {{if .IsGateway}}<span class="badge">gateway</span>

--- a/go/internal/web/web.go
+++ b/go/internal/web/web.go
@@ -47,6 +47,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/device", s.handleDevice)
 	mux.HandleFunc("/inspect", s.handleInspect)
 	mux.HandleFunc("/label", s.handleLabel)
+	mux.HandleFunc("/consent", s.handleConsent)
 	mux.HandleFunc("/api/state", s.handleAPIState)
 	return mux
 }
@@ -105,6 +106,17 @@ func portList(m map[string]any) []string {
 		out = append(out, port)
 	}
 	return out
+}
+
+// handleConsent records the user's explicit opt-in/out for research data sharing
+// (#306). Default is off; this is the only way the dashboard turns it on.
+func (s *Server) handleConsent(w http.ResponseWriter, r *http.Request) {
+	on := r.URL.Query().Get("on") == "1"
+	if err := s.st.SetShareConsent(on); err != nil {
+		http.Error(w, err.Error(), 500)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // labelFields are the user-confirmable metadata keys (vendor and device type are
@@ -233,6 +245,7 @@ func (s *Server) handleAPIState(w http.ResponseWriter, r *http.Request) {
 		"devices":   len(list),
 		"inspected": s.st.InspectedCount(),
 		"dataUse":   s.st.BytesSince(now - 10),
+		"consent":   s.st.ShareConsent(),
 		"list":      list,
 	})
 }


### PR DESCRIPTION
closes #306.

opt-in upload of captures, privacy-first: nothing leaves the machine unless the user explicitly consents AND an endpoint is configured.

- consent is stored in the db, default off (opt-in only). surfaced as a checkbox + disclosure on the dashboard, and a `-share` flag for headless runs.
- the disclosure states plainly that the full packet capture (.pcap) of the inspected devices plus the accompanying device metadata is uploaded, and opens with why ("we collect data to understand device behavior").
- the endpoint is configurable (`-collect-endpoint` / `INSPECTOR_COLLECT_ENDPOINT`), default empty = disabled. `-collect-key` for auth.
- on exit, when consent is on, it packages the pcap + a metadata json and streams them as one multipart POST, and ensures a pcap is recorded so there's something to share.
- also renames the dashboard title to "IoT Inspector".

the consent gate is the load-bearing control and is tested directly: no upload without consent, no upload without an endpoint, upload only when both. verified via live run(s): the dashboard checkbox (off by default) persists to the db, and the upload reaches a stub endpoint only after opt-in.
