### PR TITLE
device summary on the dashboard (#308)

### DIFF
--- a/go/internal/summary/summary.go
+++ b/go/internal/summary/summary.go
@@ -1,0 +1,48 @@
+// Package summary builds a short, plain-language blurb describing a device from
+// the facts already collected (issue #308). Deterministic and local: no model,
+// no network, no install — it works for every user and can't hallucinate.
+package summary
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Describe composes a plain-language summary from whatever facts are known.
+// Empty facts are skipped. name is expected to be non-empty (a label always
+// exists); the rest are best-effort.
+func Describe(name, vendor, typ string, hostnames, ports []string) string {
+	var sentences []string
+
+	switch {
+	case typ != "" && vendor != "":
+		sentences = append(sentences, name+" looks like a "+typ+", likely made by "+vendor+".")
+	case typ != "":
+		sentences = append(sentences, name+" looks like a "+typ+".")
+	case vendor != "":
+		sentences = append(sentences, name+" appears to be a device made by "+vendor+".")
+	default:
+		sentences = append(sentences, name+" is an unidentified device.")
+	}
+
+	if top := firstN(hostnames, 3); len(top) > 0 {
+		sentences = append(sentences, "It mainly communicates with "+strings.Join(top, ", ")+".")
+	}
+
+	if len(ports) > 0 {
+		noun := "ports"
+		if len(ports) == 1 {
+			noun = "port"
+		}
+		sentences = append(sentences, "It has "+strconv.Itoa(len(ports))+" open "+noun+" ("+strings.Join(firstN(ports, 5), ", ")+").")
+	}
+
+	return strings.Join(sentences, " ")
+}
+
+func firstN(s []string, n int) []string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}

--- a/go/internal/summary/summary_test.go
+++ b/go/internal/summary/summary_test.go
@@ -1,0 +1,33 @@
+package summary
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDescribe(t *testing.T) {
+	got := Describe("front-cam", "Wyze", "camera", []string{"a.com", "b.com"}, []string{"443", "554"})
+	for _, want := range []string{"front-cam", "camera", "Wyze", "a.com", "b.com", "2 open ports", "443", "554"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary missing %q\n%s", want, got)
+		}
+	}
+
+	// Only a vendor known.
+	if g := Describe("Device A", "Acme", "", nil, nil); !strings.Contains(g, "made by Acme") {
+		t.Errorf("vendor-only summary = %q", g)
+	}
+	// Nothing known but the name.
+	if g := Describe("Device B", "", "", nil, nil); !strings.Contains(g, "unidentified") {
+		t.Errorf("unknown summary = %q", g)
+	}
+	// Singular port grammar.
+	if g := Describe("x", "", "camera", nil, []string{"443"}); !strings.Contains(g, "1 open port (") {
+		t.Errorf("singular port grammar = %q", g)
+	}
+	// Caps hostnames at 3.
+	g := Describe("x", "", "", []string{"1", "2", "3", "4", "5"}, nil)
+	if strings.Contains(g, "4") || strings.Contains(g, "5") {
+		t.Errorf("should cap hostnames at 3: %q", g)
+	}
+}

--- a/go/internal/web/templates.go
+++ b/go/internal/web/templates.go
@@ -178,6 +178,7 @@ var deviceTmpl = template.Must(template.New("device").Funcs(funcs).Parse(`<!doct
 <div class="charts-stack">{{.Upload}}{{.Download}}</div>
 {{else}}<p class="empty">Not inspected — start inspection above to capture this device's traffic.</p>{{end}}
 </div>
+{{if .Summary}}<div class="card"><h2>Summary</h2><p>{{.Summary}}</p></div>{{end}}
 <div class="card"><h2>Identity</h2>
 <div class="kv">
  <div>IP</div><div>{{.IP}}</div>

--- a/go/internal/web/web.go
+++ b/go/internal/web/web.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/nyu-mlab/inspector-go/internal/store"
+	"github.com/nyu-mlab/inspector-go/internal/summary"
 	"github.com/nyu-mlab/inspector-go/internal/traffic"
 )
 
@@ -48,6 +49,62 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/label", s.handleLabel)
 	mux.HandleFunc("/api/state", s.handleAPIState)
 	return mux
+}
+
+// deviceSummary composes the plain-language blurb for a device from its facts
+// (#308) — deterministic and local, no model.
+func (s *Server) deviceSummary(mac string, m map[string]any) string {
+	vendor := str(m["vendor_confirmed"])
+	if vendor == "" {
+		vendor = str(m["oui_vendor"])
+	}
+	typ := str(m["type_confirmed"])
+	if typ == "" {
+		typ = inferType(m)
+	}
+	return summary.Describe(displayName(m), vendor, typ, s.topHostnames(mac, 5), portList(m))
+}
+
+// topHostnames returns the device's most-contacted destinations by bytes.
+func (s *Server) topHostnames(mac string, n int) []string {
+	rows, err := s.st.DB().Query(`
+		SELECT COALESCE(NULLIF(f.dest_hostname,''), h.hostname, f.dest_ip_address) AS host, SUM(f.byte_count) b
+		FROM network_flows f
+		LEFT JOIN hostnames h ON h.ip_address = f.dest_ip_address
+		WHERE f.src_mac_address = ?
+		GROUP BY host ORDER BY b DESC LIMIT ?`, mac, n)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var h string
+		var b int64
+		if rows.Scan(&h, &b) == nil && h != "" {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+// portList renders the port_scan metadata (#303, when present) as "port (banner)".
+func portList(m map[string]any) []string {
+	ps, ok := m["port_scan"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for port, v := range ps {
+		if info, ok := v.(map[string]any); ok {
+			if b := str(info["banner"]); b != "" {
+				out = append(out, port+" ("+b+")")
+				continue
+			}
+		}
+		out = append(out, port)
+	}
+	return out
 }
 
 // labelFields are the user-confirmable metadata keys (vendor and device type are
@@ -256,6 +313,7 @@ func (s *Server) handleDevice(w http.ResponseWriter, r *http.Request) {
 		"Contacts":  contacts,
 		"Upload":    lineChart(up, "↑ Upload Traffic (sent by device) — last 60s"),
 		"Download":  lineChart(down, "↓ Download Traffic (received) — last 60s"),
+		"Summary": s.deviceSummary(mac, m), // plain-language blurb (#308)
 	})
 }
 


### PR DESCRIPTION
closes #308.

the device page now shows a short summary of each device, built from the facts already collected:

> front-door-cam looks like a camera, likely made by Wyze Labs. It mainly communicates with device-api.wyze.com, logs.wyze.com.

it's composed deterministically in go from the name, vendor, type, top contacted hostnames, and open ports (when present), so there's no model, network, or install, and it works for every user without hallucinating. the issue floated a local model; that only works for users who've installed ollama and pulled a model, so a template is the version that actually reaches everyone.

always shown, nothing to enable.
