### PR TITLE
add device-id rate limits (#309)

### DIFF
--- a/go/internal/devid/devid.go
+++ b/go/internal/devid/devid.go
@@ -10,8 +10,42 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 )
+
+// RateLimitError is returned when the endpoint replies 429. RetryAfter is parsed
+// from the Retry-After header (0 if absent), so a caller can back off for that
+// long instead of hammering the API (#309).
+type RateLimitError struct {
+	RetryAfter time.Duration
+}
+
+func (e *RateLimitError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("device-id API rate limited; retry after %s", e.RetryAfter)
+	}
+	return "device-id API rate limited"
+}
+
+// parseRetryAfter reads a Retry-After value, which RFC 7231 allows to be either
+// a number of seconds or an HTTP date.
+func parseRetryAfter(h string) time.Duration {
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(h); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(h); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
+		}
+	}
+	return 0
+}
 
 const defaultEndpoint = "https://rameen-mahmood--dev-id-predict.modal.run"
 
@@ -79,6 +113,9 @@ func (c *Client) Predict(ctx context.Context, mac string, f Fields) (map[string]
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, &RateLimitError{RetryAfter: parseRetryAfter(resp.Header.Get("Retry-After"))}
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("device-id API returned %s", resp.Status)
 	}

--- a/go/internal/devid/devid_test.go
+++ b/go/internal/devid/devid_test.go
@@ -1,0 +1,85 @@
+package devid
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func twoFields() Fields { return Fields{OUIFriendly: "Acme", DHCPHostname: "cam"} }
+
+func client(url string) *Client {
+	c := New("tok")
+	c.Endpoint = url
+	return c
+}
+
+func TestPredictRateLimited(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	_, err := client(srv.URL).Predict(context.Background(), "aa:bb", twoFields())
+	var rl *RateLimitError
+	if !errors.As(err, &rl) {
+		t.Fatalf("expected *RateLimitError, got %v", err)
+	}
+	if rl.RetryAfter != 30*time.Second {
+		t.Errorf("RetryAfter = %s, want 30s", rl.RetryAfter)
+	}
+}
+
+func TestPredictRateLimitedNoHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	_, err := client(srv.URL).Predict(context.Background(), "aa:bb", twoFields())
+	var rl *RateLimitError
+	if !errors.As(err, &rl) || rl.RetryAfter != 0 {
+		t.Fatalf("expected *RateLimitError with 0 retry, got %v", err)
+	}
+}
+
+func TestPredictOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"vendor":"Wyze"}`))
+	}))
+	defer srv.Close()
+
+	out, err := client(srv.URL).Predict(context.Background(), "aa:bb", twoFields())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out["vendor"] != "Wyze" {
+		t.Errorf("vendor = %v, want Wyze", out["vendor"])
+	}
+}
+
+func TestPredictOtherErrorIsNotRateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := client(srv.URL).Predict(context.Background(), "aa:bb", twoFields())
+	var rl *RateLimitError
+	if err == nil || errors.As(err, &rl) {
+		t.Errorf("401 should be a generic error, got %v", err)
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	cases := map[string]time.Duration{"": 0, "45": 45 * time.Second, "-5": 0, "abc": 0}
+	for in, want := range cases {
+		if got := parseRetryAfter(in); got != want {
+			t.Errorf("parseRetryAfter(%q) = %s, want %s", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
fixes #309 (client side)

the dev-id api collapsed every non-200 into a generic error, so a 429 was indistinguishable from a real failure and there was nothing to back off on.

now Predict returns a typed `*RateLimitError` on 429, carrying `RetryAfter` parsed from the Retry-After header (seconds or http-date, 0 if absent), so a caller can wait that long instead of hammering the endpoint.

the server already does the limiting (per-IP + per-token). the remaining server gaps, sending a Retry-After header and public-vs-private key tiers, are tracked separately on the dev-id repo.
